### PR TITLE
[Removed] Special resist from composite and adv composite segments

### DIFF
--- a/MMOCoreORB/bin/scripts/object/tangible/component/armor/armor_segment_composite.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/component/armor/armor_segment_composite.lua
@@ -49,8 +49,8 @@ object_tangible_component_armor_armor_segment_composite = object_tangible_compon
 	experimentalWeights = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
 	experimentalGroupTitles = {"null", "null", "exp_durability", "exp_quality", "exp_durability", "exp_durability", "exp_durability", "exp_durability", "null", "null", "exp_resistance", "null"},
 	experimentalSubGroupTitles = {"null", "null", "hit_points", "armor_effectiveness", "armor_integrity", "armor_health_encumbrance", "armor_action_encumbrance", "armor_mind_encumbrance", "armor_rating", "armor_special_type", "armor_special_effectiveness", "armor_special_integrity"},
-	experimentalMin = {0, 0, 1000, 1, 100, 13, 13, 16, 1, 256, 1, 100},
-	experimentalMax = {0, 0, 1000, 10, 1000, 1, 1, 1, 1, 256, 15, 1000},
+	experimentalMin = {0, 0, 1000, 1, 100, 13, 13, 16, 1, 0, 1, 100},
+	experimentalMax = {0, 0, 1000, 10, 1000, 1, 1, 1, 1, 0, 10, 1000},
 	experimentalPrecision = {0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0},
 	experimentalCombineType = {0, 0, 1, 1, 1, 1, 1, 1, 4, 4, 4, 1},
 }

--- a/MMOCoreORB/bin/scripts/object/tangible/component/armor/armor_segment_composite_advanced.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/component/armor/armor_segment_composite_advanced.lua
@@ -49,8 +49,8 @@ object_tangible_component_armor_armor_segment_composite_advanced = object_tangib
 	experimentalWeights = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
 	experimentalGroupTitles = {"null", "null", "exp_durability", "exp_quality", "exp_durability", "exp_durability", "exp_durability", "exp_durability", "null", "null", "exp_resistance", "null"},
 	experimentalSubGroupTitles = {"null", "null", "hit_points", "armor_effectiveness", "armor_integrity", "armor_health_encumbrance", "armor_action_encumbrance", "armor_mind_encumbrance", "armor_rating", "armor_special_type", "armor_special_effectiveness", "armor_special_integrity"},
-	experimentalMin = {0, 0, 1000, 1, 100, 13, 13, 16, 1, 256, 1, 100},
-	experimentalMax = {0, 0, 1000, 25, 1000, 1, 1, 1, 1, 256, 35, 1000},
+	experimentalMin = {0, 0, 1000, 1, 100, 13, 13, 16, 1, 0, 1, 100},
+	experimentalMax = {0, 0, 1000, 15, 1000, 1, 1, 1, 1, 0, 15, 1000},
 	experimentalPrecision = {0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 10, 0},
 	experimentalCombineType = {0, 0, 1, 1, 1, 1, 1, 1, 4, 4, 4, 1},
 }


### PR DESCRIPTION
Looks like this is something Emu had changed since Tarkin shut down so there was no commit history on it and I didn't know it needed changed back.