### PR TITLE
[Mod] Newly looted/generated SEAs will only have 1 stat (as only one …

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/loot/LootManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/loot/LootManagerImplementation.cpp
@@ -453,6 +453,27 @@ TangibleObject* LootManagerImplementation::createLootObject(LootItemTemplate* te
 		addConditionDamage(prototype, craftingValues);
 
 	delete craftingValues;
+	
+	// Set SEA name as: [first mod name] [mod value]
+	if (prototype->isAttachment()){
+		Attachment* sea = cast<Attachment*>( prototype.get());
+		
+		if (sea == NULL)
+			return prototype;
+	
+		HashTable<String, int>* mods = sea->getSkillMods();
+ 		HashTableIterator<String, int> iterator = mods->iterator();
+ 		
+ 		String key = "";
+ 		int value = 0;
+ 		StringId attachmentName;
+ 		
+ 		iterator.getNextKeyAndValue(key, value);
+ 		attachmentName.setStringId("stat_n", key);
+ 		prototype->setObjectName(attachmentName, false);
+ 		
+		prototype->setCustomObjectName(prototype->getDisplayedName() + " " + String::valueOf(value), false);
+	}
 
 	return prototype;
 }

--- a/MMOCoreORB/src/server/zone/objects/tangible/attachment/AttachmentImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/attachment/AttachmentImplementation.cpp
@@ -20,29 +20,19 @@ void AttachmentImplementation::initializeTransientMembers() {
 
 void AttachmentImplementation::updateCraftingValues(CraftingValues* values, bool firstUpdate) {
 	int level = values->getMaxValue("creatureLevel");
-	int roll = System::random(100);
-	int modCount = 1;
 
-	if(roll > 99)
-		modCount += 2;
+	//Mods can't be lower than -1 or greater than 25
+	int max = MAX(-1, MIN(25, round(0.1f * level + 3)));
+	int min = MAX(-1, MIN(25, round(0.075f * level - 1)));
 
-	if(roll < 5)
-		modCount += 1;
+	int mod = System::random(max - min) + min;
 
-	for(int i = 0; i < modCount; ++i) {
-		//Mods can't be lower than -1 or greater than 25
-		int max = MAX(-1, MIN(25, round(0.1f * level + 3)));
-		int min = MAX(-1, MIN(25, round(0.075f * level - 1)));
+	if(mod == 0)
+		mod = 1;
 
-		int mod = System::random(max - min) + min;
+	String modName = server->getZoneServer()->getLootManager()->getRandomLootableMod(gameObjectType);
 
-		if(mod == 0)
-			mod = 1;
-
-		String modName = server->getZoneServer()->getLootManager()->getRandomLootableMod(gameObjectType);
-
-		skillModMap.put(modName, mod);
-	}
+	skillModMap.put(modName, mod);
 }
 
 void AttachmentImplementation::initializeMembers() {


### PR DESCRIPTION
…ever gets used anyway) and their display name will show the stat name and power, such as "Carbine Speed 14".

I thought you might like this minor QoL mod, as it makes using SEAs way less confusing (there's only one mod, so one mod goes in one socket - simple, unlike the 14.1 way of using only the highest one) and it makes them easier to view on vendors.