### PR TITLE
[Fix] /tarkin aboutMe: Replaced display of player chosen house names …

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/creature/commands/TarkinCommand.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/commands/TarkinCommand.h
@@ -116,9 +116,12 @@ public:
 				body << "NULL Structure" << endl;
 				continue;
 			}
+			
+			StringIdManager* sidman = StringIdManager::instance();
+			String buildingName = sidman->getStringId("@building_name:" + structure->getObjectNameStringIdName()).toString();
 
-			body << "Name: " << structure->getCustomObjectName().toString() << endl;
-			body << "    Type: " << structure->getObjectNameStringIdName() << endl;
+			body << buildingName << endl;
+			//body << "    Type: " << structure->getObjectNameStringIdName() << endl; // debug
 			body << "    Lots: " << String::valueOf(structure->getLotSize()) << endl;
 			body << "    Maintenance Pool: " << String::valueOf(structure->getSurplusMaintenance()) << " credits" << endl;
 			body << "    Maintenance Rate: " << String::valueOf(structure->getMaintenanceRate()) << " credits/hr" << endl;


### PR DESCRIPTION
…with the default display name of building. This prevents the output from being truncated when a player uses a tilde ~ symbol in the house name (and it's easier to read anyway).